### PR TITLE
結果判定ロジックを修正

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,7 +57,7 @@ export default function BrandingTest() {
   }
 
   const calculateResult = (answers: Record<string, Answer>): string => {
-    // Q1でNOを選択した場合
+    // Q1でNOを選択した場合 → とりあえずはじまり研究者タイプ（後で決定）
     if (answers["q1"] === false) {
       return "hajimari"
     }
@@ -72,15 +72,25 @@ export default function BrandingTest() {
       return "hajimari"
     }
 
-    // Q3でYES、Q4でNOを選択した場合
-    if (answers["q3"] === true && answers["q4"] === false) {
+    // Q3でNOを選択した場合
+    if (answers["q3"] === false) {
+      return "hajimari"
+    }
+
+    // Q1「はい」→Q1-2「新規ブランド」→Q3「はい」/Q4「いいえ」→ チャレンジャータイプ
+    if (
+      answers["q1"] === true &&
+      answers["q1-2"] === "新規ブランド" &&
+      answers["q3"] === true &&
+      answers["q4"] === false
+    ) {
       return "challenger"
     }
 
     // All YES (Q1: YES, Q1-2: 新ブランド, Q2: YES, Q3: YES, Q4: YES)
     if (
       answers["q1"] === true &&
-      answers["q1-2"] === "新ブランド" &&
+      answers["q1-2"] === "新規ブランド" &&
       answers["q2"] === true &&
       answers["q3"] === true &&
       answers["q4"] === true


### PR DESCRIPTION
## 変更内容

### 🔧 修正項目
- 結果判定ロジック（`calculateResult`関数）の条件分岐を修正
- フローチャートの分岐条件と結果が完全に一致するように調整

### 📋 修正した判定パターン

**修正前の問題点：**
- Q3で「いいえ」を選択した場合の処理が抜けていた
- 一部の分岐条件が仕様と異なっていた

**修正後の正しいフロー：**
1. Q1「いいえ」→ はじまり研究者タイプ（暫定）
2. Q1「はい」→Q1-2「リブランディング」→ らしさ探求者タイプ ✅
3. Q1「はい」→Q1-2「新規ブランド」→Q2「いいえ」→ はじまり研究者タイプ ✅
4. Q1「はい」→Q1-2「新規ブランド」→Q2「はい」→Q3「いいえ」→ はじまり研究者タイプ ✅
5. Q1「はい」→Q1-2「新規ブランド」→Q2「はい」→Q3「はい」→Q4「いいえ」→ チャレンジャータイプ ✅
6. Q1「はい」→Q1-2「新規ブランド」→Q2「はい」→Q3「はい」→Q4「はい」→ ブラッシュアップ職人タイプ ✅
